### PR TITLE
Make solve optional for Code quiz

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+git+https://github.com/StepicOrg/stepic-common.git

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -5,7 +5,7 @@ import subprocess
 import datetime
 import os
 
-VERSION = (1, 1, 0, 'final', 0)
+VERSION = (1, 2, 0, 'final', 0)
 
 
 def get_version(version=None):

--- a/src/stepic_utils/stepicrun.py
+++ b/src/stepic_utils/stepicrun.py
@@ -13,6 +13,7 @@ SCORE_COMMAND = 'score'
 SOLVE_COMMAND = 'solve'
 TEST_COMMAND = 'test'
 SAMPLE_COMMAND = 'sample'
+HAS_SOLVE_COMMAND = 'has_solve'
 
 DATASET_QUIZ = 'dataset'
 CODE_QUIZ = 'code'
@@ -50,6 +51,9 @@ class Runner(object):
     def sample(self):
         return self.encode(self.quiz.sample)
 
+    def has_solve(self):
+        return self.encode(self.quiz.has_solve)
+
 
 def read_bin_stdin():
     binary_input = sys.stdin.buffer.read()
@@ -60,15 +64,15 @@ def write_bin_stdout(data):
     sys.stdout.buffer.write(data)
 
 
-def main():
+def main(args=None):
     parser = argparse.ArgumentParser(description='Test or run python exercise')
     parser.add_argument('-c', '--command', required=True,
                         choices=[GENERATE_COMMAND, SCORE_COMMAND, SOLVE_COMMAND, TEST_COMMAND,
-                                 SAMPLE_COMMAND])
+                                 SAMPLE_COMMAND, HAS_SOLVE_COMMAND])
     parser.add_argument('-p', '--code-path', default='user_code.py')
     parser.add_argument('-s', '--seed', type=int)
     parser.add_argument('-t', '--type', default=DATASET_QUIZ, choices=[DATASET_QUIZ, CODE_QUIZ, STRING_QUIZ])
-    args = parser.parse_args()
+    args = parser.parse_args(args=args)
 
     if args.type == DATASET_QUIZ:
         quiz_class = DatasetQuiz
@@ -105,8 +109,15 @@ def main():
     elif args.command == SAMPLE_COMMAND:
         sample = runner.sample()
         sys.stdout.buffer.write(sample)
+    elif args.command == HAS_SOLVE_COMMAND:
+        if quiz_class != CodeQuiz:
+            print("error: '{}' command is applicable only for {} quiz."
+                  .format(HAS_SOLVE_COMMAND, CODE_QUIZ))
+            sys.exit(1)
+        write_bin_stdout(runner.has_solve())
     else:
         assert False, 'unknown command'
+
 
 if __name__ == '__main__':
     main()

--- a/src/stepic_utils/tests/examples/code/generate_datasets.py
+++ b/src/stepic_utils/tests/examples/code/generate_datasets.py
@@ -4,7 +4,8 @@ def generate():
 
 def solve(dataset):
     assert dataset in ['2 2\n', '5 7\n']
-    return str(sum(map(int, dataset.split())))
+    a, b = dataset.split()
+    return str(int(a) + int(b))
 
 
 def check(reply, clue):

--- a/src/stepic_utils/tests/examples/code/generate_datasets.py
+++ b/src/stepic_utils/tests/examples/code/generate_datasets.py
@@ -1,0 +1,12 @@
+def generate():
+    return ['2 2\n', '5 7\n']
+
+
+def solve(dataset):
+    assert dataset in ['2 2\n', '5 7\n']
+    return str(sum(map(int, dataset.split())))
+
+
+def check(reply, clue):
+    assert clue in ['4', '12']
+    return reply == clue

--- a/src/stepic_utils/tests/examples/code/generate_datasets_without_solve.py
+++ b/src/stepic_utils/tests/examples/code/generate_datasets_without_solve.py
@@ -1,0 +1,8 @@
+def generate():
+    return ['2 2\n', '5 7\n']
+
+
+def check(reply, clue):
+    assert clue is None
+    # Unable to check without dataset or clue
+    return False

--- a/src/stepic_utils/tests/examples/code/generate_tuples.py
+++ b/src/stepic_utils/tests/examples/code/generate_tuples.py
@@ -1,0 +1,12 @@
+def generate():
+    return [('2 2\n', 'clue:4'), ('5 7\n', 'clue:12')]
+
+
+def solve(dataset):
+    assert dataset in ['2 2\n', '5 7\n']
+    return str(sum(map(int, dataset.split())))
+
+
+def check(reply, clue):
+    assert clue in ['clue:4', 'clue:12']
+    return reply == clue[5:]

--- a/src/stepic_utils/tests/examples/code/generate_tuples.py
+++ b/src/stepic_utils/tests/examples/code/generate_tuples.py
@@ -4,7 +4,8 @@ def generate():
 
 def solve(dataset):
     assert dataset in ['2 2\n', '5 7\n']
-    return str(sum(map(int, dataset.split())))
+    a, b = dataset.split()
+    return str(int(a) + int(b))
 
 
 def check(reply, clue):

--- a/src/stepic_utils/tests/examples/code/generate_tuples_without_solve.py
+++ b/src/stepic_utils/tests/examples/code/generate_tuples_without_solve.py
@@ -1,0 +1,7 @@
+def generate():
+    return [('2 2\n', 'clue:4'), ('5 7\n', 'clue:12')]
+
+
+def check(reply, clue):
+    assert clue in ['clue:4', 'clue:12']
+    return reply == clue[5:]

--- a/src/stepic_utils/tests/test.py
+++ b/src/stepic_utils/tests/test.py
@@ -1,16 +1,41 @@
 import os
+import textwrap
 
+from io import StringIO
+from contextlib import contextmanager
+from importlib.machinery import ModuleSpec
+from importlib.util import module_from_spec
 from unittest import TestCase
+from unittest.mock import patch
 
-from ..quiz import DatasetQuiz, StringQuiz
-
-
-def get_quiz(name, quiz_cls=DatasetQuiz):
-    examples_dir = os.path.join(os.path.dirname(__file__), 'examples')
-    path = os.path.join(examples_dir, name)
-    return quiz_cls.import_quiz(path)
+from stepic_utils.quiz import check_signatures
+from ..quiz import CodeQuiz, DatasetQuiz, StringQuiz
 
 
+class BaseTest(TestCase):
+    @contextmanager
+    def assert_fail_with_message(self, expected_message):
+        fake_stderr = StringIO()
+        with patch('sys.stderr', fake_stderr):
+            with self.assertRaises(SystemExit):
+                yield
+            stderr = fake_stderr.getvalue()
+            self.assertEqual(stderr, expected_message,
+                             "Expected: {}\nGot: {}".format(expected_message, stderr))
+
+
+def get_quiz(name=None, code=None, quiz_cls=DatasetQuiz):
+    if name is not None:
+        examples_dir = os.path.join(os.path.dirname(__file__), 'examples')
+        path = os.path.join(examples_dir, name)
+        return quiz_cls.import_quiz(path)
+    if code is not None:
+        quiz_module = module_from_spec(ModuleSpec('quiz', None))
+        exec(code, {}, quiz_module.__dict__)
+        return quiz_cls.import_quiz(quiz_module)
+
+
+# noinspection PyTypeChecker
 class ExamplesTest(TestCase):
     def test_ab(self):
         quiz = get_quiz('ab.py')
@@ -51,3 +76,105 @@ class ExamplesTest(TestCase):
     def test_self_check_fail(self):
         quiz = get_quiz('string_quiz_with_solve_fail.py', quiz_cls=StringQuiz)
         self.assertFalse(quiz.self_check())
+
+
+class CheckSignatureTest(BaseTest):
+    def test_valid(self):
+        specs = [('f', lambda: None, 0),
+                 ('f', lambda *args: None, 0),
+                 ('f', lambda x: None, 1),
+                 ('f', lambda *args: None, 1),
+                 ('f', lambda x, *args: None, 1),
+                 ('f', lambda x, y: None, 2),
+                 ('f', lambda *args: None, 2),
+                 ('f', lambda x, *args: None, 2),
+                 ('f', lambda x, y, *args: None, 2)]
+
+        self.assertIsNone(check_signatures(specs))
+
+    def test_wrong_number_of_args_1_expected(self):
+        invalid_funcs = [
+            lambda: None,
+            lambda x, y: None,
+            lambda x, y, z: None,
+        ]
+        for f in invalid_funcs:
+            specs = [('f', f, 1)]
+
+            with self.assert_fail_with_message("`f` should accept 1 argument.\n"):
+                check_signatures(specs)
+
+    def test_wrong_number_of_args_2_expected(self):
+        invalid_funcs = [
+            lambda: None,
+            lambda x: None,
+            lambda x, y, z: None,
+        ]
+        for f in invalid_funcs:
+            specs = [('f', f, 2)]
+
+            with self.assert_fail_with_message("`f` should accept 2 arguments.\n"):
+                check_signatures(specs)
+
+
+# noinspection PyTypeChecker
+class CodeQuizTest(BaseTest):
+    def test_generate_required(self):
+        expected_msg = ("Can't import 'generate' from the challenge module.\n"
+                        "It should export 'generate', 'check' functions.\n")
+
+        with self.assert_fail_with_message(expected_msg):
+            get_quiz(code="", quiz_cls=CodeQuiz)
+
+    def test_check_required(self):
+        code = textwrap.dedent("""
+            def generate():
+                return []
+            """)
+        expected_msg = ("Can't import 'check' from the challenge module.\n"
+                        "It should export 'generate', 'check' functions.\n")
+
+        with self.assert_fail_with_message(expected_msg):
+            get_quiz(code=code, quiz_cls=CodeQuiz)
+
+    def test_generate_datasets(self):
+        quiz = get_quiz('code/generate_datasets.py', quiz_cls=CodeQuiz)
+
+        tests = quiz.generate()
+
+        self.assertEqual(tests, [('2 2\n', '4'), ('5 7\n', '12')])
+
+    def test_generate_tuples(self):
+        quiz = get_quiz('code/generate_tuples.py', quiz_cls=CodeQuiz)
+
+        tests = quiz.generate()
+
+        self.assertEqual(tests, [('2 2\n', 'clue:4'), ('5 7\n', 'clue:12')])
+
+    def test_generate_datasets_without_solve(self):
+        quiz = get_quiz('code/generate_datasets_without_solve.py', quiz_cls=CodeQuiz)
+
+        tests = quiz.generate()
+
+        self.assertEqual(tests, [('2 2\n', None), ('5 7\n', None)])
+
+    def test_generate_tuples_without_solve(self):
+        quiz = get_quiz('code/generate_tuples_without_solve.py', quiz_cls=CodeQuiz)
+
+        tests = quiz.generate()
+
+        self.assertEqual(tests, [('2 2\n', 'clue:4'), ('5 7\n', 'clue:12')])
+
+    def test_self_check_success(self):
+        for name in ['code/generate_datasets.py',
+                     'code/generate_tuples.py']:
+            quiz = get_quiz(name, quiz_cls=CodeQuiz)
+
+            self.assertTrue(quiz.self_check())
+
+    def test_self_check_without_solve_success(self):
+        for name in ['code/generate_datasets_without_solve.py',
+                     'code/generate_tuples_without_solve.py']:
+            quiz = get_quiz(name, quiz_cls=CodeQuiz)
+
+            self.assertTrue(quiz.self_check())

--- a/src/stepic_utils/tests/test_quiz.py
+++ b/src/stepic_utils/tests/test_quiz.py
@@ -1,27 +1,12 @@
 import os
 import textwrap
 
-from io import StringIO
-from contextlib import contextmanager
 from importlib.machinery import ModuleSpec
 from importlib.util import module_from_spec
 from unittest import TestCase
-from unittest.mock import patch
 
-from stepic_utils.quiz import check_signatures
-from ..quiz import CodeQuiz, DatasetQuiz, StringQuiz
-
-
-class BaseTest(TestCase):
-    @contextmanager
-    def assert_fail_with_message(self, expected_message):
-        fake_stderr = StringIO()
-        with patch('sys.stderr', fake_stderr):
-            with self.assertRaises(SystemExit):
-                yield
-            stderr = fake_stderr.getvalue()
-            self.assertEqual(stderr, expected_message,
-                             "Expected: {}\nGot: {}".format(expected_message, stderr))
+from .utils import BaseTest
+from ..quiz import CodeQuiz, DatasetQuiz, StringQuiz, check_signatures
 
 
 def get_quiz(name=None, code=None, quiz_cls=DatasetQuiz):

--- a/src/stepic_utils/tests/test_run.py
+++ b/src/stepic_utils/tests/test_run.py
@@ -1,0 +1,13 @@
+from .utils import BaseTest
+
+
+class RunTest(BaseTest):
+    def test_has_solve_true(self):
+        args = ('-t', 'code', '-p', 'code/generate_datasets.py', '-c', 'has_solve')
+
+        self.assert_run_result(args, True)
+
+    def test_has_solve_false(self):
+        args = ('-t', 'code', '-p', 'code/generate_datasets_without_solve.py', '-c', 'has_solve')
+
+        self.assert_run_result(args, False)

--- a/src/stepic_utils/tests/utils.py
+++ b/src/stepic_utils/tests/utils.py
@@ -1,0 +1,26 @@
+from contextlib import contextmanager
+from io import StringIO, BytesIO
+from unittest import TestCase
+from unittest.mock import patch
+
+from ..stepicrun import main
+from ..utils import decode
+
+
+class BaseTest(TestCase):
+    @contextmanager
+    def assert_fail_with_message(self, expected_message):
+        fake_stderr = StringIO()
+        with patch('sys.stderr', fake_stderr):
+            with self.assertRaises(SystemExit):
+                yield
+        stderr = fake_stderr.getvalue()
+        self.assertEqual(stderr, expected_message)
+
+    def assert_run_result(self, args, expected_result):
+        fake_buffer = BytesIO()
+        with patch('sys.stdout') as mock_stdout:
+            mock_stdout.buffer = fake_buffer
+            main(args=args)
+        result = decode(fake_buffer.getvalue())
+        self.assertEqual(result, expected_result)

--- a/src/stepic_utils/utils.py
+++ b/src/stepic_utils/utils.py
@@ -42,6 +42,8 @@ class JSONEncoder(json.JSONEncoder):
 class JSONDecoder(json.JSONDecoder):
     def decode(self, s, **kwargs):
         obj = super().decode(s, **kwargs)
+        if not isinstance(obj, dict):
+            return obj
         if '_serialized.decimal' in obj:
             return decimal.Decimal(obj['_serialized.decimal'])
         if '_serialized.datetime' in obj:


### PR DESCRIPTION
**Кто должен одобрить:**
* [x] @meanmail 
* [ ] @psviderski

Функция `solve` в коде Code квиза сделана необязательной. Если присутствует, проверяется корректная сигнатура и поведения остается, как и было раньше.

#### `solve` отсутствует:
* Если функция `generate` возвращает список строк (датасетов), то команда `generate` вернет список пар `(dataset, clue)`, где `clue` = `None`;
* Если функция `generate` возвращает список пар `(dataset, clue)`, то команда `generate` вернет этот же список.

Только для Code квиза добавлена команда `has_solve`, возвращает `bool` — определена или нет функция `solve` в коде квиза.
Добавлены тесты.